### PR TITLE
[Patch] Log metrics only on main process in distributed training

### DIFF
--- a/get_model/finetune.py
+++ b/get_model/finetune.py
@@ -381,6 +381,13 @@ def main(args, ds_init):
 
     print(args)
 
+    if utils.is_main_process(): # Log metrics only on main process
+        wandb.login()
+        run = wandb.init(
+            project=opts.wandb_project_name,
+            name=opts.wandb_run_name,
+        )
+
     device = torch.device(args.device)
 
     # fix the seed for reproducibility
@@ -872,11 +879,4 @@ if __name__ == "__main__":
 
     if opts.output_dir:
         Path(opts.output_dir).mkdir(parents=True, exist_ok=True)
-
-    wandb.login()
-    if utils.is_main_process(): # Log metrics only on main process
-        run = wandb.init(
-            project=opts.wandb_project_name,
-            name=opts.wandb_run_name,
-        )
     main(opts, ds_init)

--- a/scripts/run_finetune_from_scratch.sh
+++ b/scripts/run_finetune_from_scratch.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+OUTPUT_DIR='/pmglocal/alb2281/repos/get_model/output/'
+DATA_PATH='/pmglocal/alb2281/repos/get_model/data/pretrain_B_ALL_2023/'
+PORT=7956
+
+# batch_size can be adjusted according to the graphics card
+OMP_NUM_THREADS=1 python -m torch.distributed.run --nproc_per_node=2 /pmglocal/alb2281/repos/get_model/get_model/finetune.py \
+    --data_set "Expression" \
+    --data_path ${DATA_PATH} \
+    --input_dim 283 \
+    --eval_freq 1 \
+    --criterion "poisson" \
+    --data_type B_ALL \
+    --model get_finetune_motif \
+    --use_natac \
+    --finetune /pmglocal/alb2281/repos/get_model/ckpts/checkpoint-1579.pth \
+    --batch_size 64 \
+    --leave_out_celltypes "MH3266" \
+    --leave_out_chromosomes "chr11" \
+    --num_workers 0\
+    --opt adamw \
+    --opt_betas 0.9 0.95 \
+    --epochs 100 \
+    --lr 1e-3 \
+    --num_region_per_sample 200 \
+    --output_dir ${OUTPUT_DIR} \
+    --wandb_project_name "get_finetune_all" \
+    --wandb_run_name "exp_0" > /pmglocal/alb2281/repos/get_model/logs/finetune_output.txt


### PR DESCRIPTION
1. Fix `wandb` to log only on main process
2. Add script for finetuning from pretrained checkpoint with `--finetune`, instead of `--resume`